### PR TITLE
회원가입시 이름 중복에 대한 예외 미처리로 인한 Internal Server Error 해결

### DIFF
--- a/src/main/java/com/gitpolio/gitpolioserver/advice/RegisterAdvice.java
+++ b/src/main/java/com/gitpolio/gitpolioserver/advice/RegisterAdvice.java
@@ -8,6 +8,8 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 
+import java.sql.SQLIntegrityConstraintViolationException;
+
 /* 다음 exception 에 대한 handling 이 필요하다
 MethodArgumentNotValidException
 RegisterFailureException
@@ -30,6 +32,11 @@ public class RegisterAdvice {
                 return ResponseEntity.badRequest().body(ErrorResponse.builder()
                         .message("이미 존재하는 이메일 입니다!")
                         .status(ErrorStatus.REGISTER_EMAIL_ALREADY_EXISTS)
+                        .build());
+            case NAME_ALREADY_EXISTS:
+                return ResponseEntity.badRequest().body(ErrorResponse.builder()
+                        .message("이미 존재하는 이름 입니다!")
+                        .status(ErrorStatus.REGISTER_NAME_ALREADY_EXISTS)
                         .build());
             default:
                 return ResponseEntity.internalServerError().body(ErrorResponse.builder()

--- a/src/main/java/com/gitpolio/gitpolioserver/advice/error/ErrorStatus.java
+++ b/src/main/java/com/gitpolio/gitpolioserver/advice/error/ErrorStatus.java
@@ -10,6 +10,7 @@ public enum ErrorStatus {
     REGISTER_ERROR(3000, "Register error"),
     REGISTER_WRONG_REGISTER_INFO(3001, "Wrong register info"),
     REGISTER_EMAIL_ALREADY_EXISTS(3002, "Register id already exists"),
+    REGISTER_NAME_ALREADY_EXISTS(3003, "Register name already exists"),
 
     LOGIN_ERROR(4000, "Login error"),
     LOGIN_ID_NOT_FOUND(4001, "Login id not found"),

--- a/src/main/java/com/gitpolio/gitpolioserver/exception/RegisterFailureException.java
+++ b/src/main/java/com/gitpolio/gitpolioserver/exception/RegisterFailureException.java
@@ -9,6 +9,6 @@ public class RegisterFailureException extends RuntimeException {
     private final Reason reason;
 
     public enum Reason {
-        EMAIL_ALREADY_EXISTS
+        NAME_ALREADY_EXISTS, EMAIL_ALREADY_EXISTS
     }
 }

--- a/src/main/java/com/gitpolio/gitpolioserver/service/AccountService.java
+++ b/src/main/java/com/gitpolio/gitpolioserver/service/AccountService.java
@@ -11,6 +11,7 @@ import com.gitpolio.gitpolioserver.exception.UnknownIdTypeException;
 import com.gitpolio.gitpolioserver.jwt.AuthTokenUtils;
 import com.gitpolio.gitpolioserver.repository.AccountRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -33,7 +34,11 @@ public class AccountService {
                 .encodedPassword(encodedPassword)
                 .githubToken(registerInfo.getGithubToken())
                 .build();
-        accountRepository.save(account);
+        try {
+            accountRepository.save(account);
+        } catch (DataIntegrityViolationException e) {
+            throw new RegisterFailureException(RegisterFailureException.Reason.NAME_ALREADY_EXISTS);
+        }
         return account.toDto();
     }
 

--- a/src/test/java/com/gitpolio/gitpolioserver/advice/RegisterAdviceTest.java
+++ b/src/test/java/com/gitpolio/gitpolioserver/advice/RegisterAdviceTest.java
@@ -38,4 +38,14 @@ public class RegisterAdviceTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertEquals(response.getBody().getStatus(), ErrorStatus.REGISTER_EMAIL_ALREADY_EXISTS);
     }
+
+    @Test
+    public void testRegisterFailureException2() {
+        RegisterFailureException exception = mock(RegisterFailureException.class);
+        when(exception.getReason()).thenReturn(RegisterFailureException.Reason.NAME_ALREADY_EXISTS);
+        ResponseEntity<ErrorResponse> response =  registerAdvice.handleException(exception);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals(response.getBody().getStatus(), ErrorStatus.REGISTER_NAME_ALREADY_EXISTS);
+    }
 }

--- a/src/test/java/com/gitpolio/gitpolioserver/service/AccountServiceTest.java
+++ b/src/test/java/com/gitpolio/gitpolioserver/service/AccountServiceTest.java
@@ -12,6 +12,7 @@ import com.gitpolio.gitpolioserver.repository.AccountRepository;
 import com.thedeanda.lorem.LoremIpsum;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
 
@@ -94,6 +95,24 @@ public class AccountServiceTest {
 
         //이메일이 중복되어야 하므로 true 를 반환한다
         when(accountRepository.existsByEmail(registerInfo.getEmail())).thenReturn(true);
+
+        //~002~003 테스트 대상 실행 및 테스트 대상 검사
+        //테스트 중 RegisterFailureException 이 throwing 되는지 검사한다
+        assertThrows(RegisterFailureException.class,
+                () -> accountService.register(registerInfo));
+    }
+
+    /*
+    이미 같은 이름 가입된 이메일이 있을경우, DataIntegrityViolationException 을 throw 하므로,
+    이를 RegisterFailureException 으로 Wrapping 하여 던져야 한다.
+     */@Test
+    public void testRegisterFailure2() {
+        //~001 테스트 환경 구성
+        //Random data 가 담긴 RegisterInfoDto 를 가져온다
+        RegisterInfoDto registerInfo = getRandomRegisterInfo();
+
+        //이름이 중복되어야 하므로 DataIntegrityViolationException 을 반환한다
+        when(accountRepository.save(any())).thenThrow(DataIntegrityViolationException.class);
 
         //~002~003 테스트 대상 실행 및 테스트 대상 검사
         //테스트 중 RegisterFailureException 이 throwing 되는지 검사한다


### PR DESCRIPTION
- AccountService 에서 DataIntegrityViolationException 발생시 RegisterFailureException 로 Wrapping 하여 throw
- RegisterFailureException.Reason 에 이름 중복 관련 enum constant 추가
- RegisterFailureException 에 대한 handling advice 수정